### PR TITLE
Add S3 bucket and dns to handle www to root domain redirects

### DIFF
--- a/cloudfront.yml
+++ b/cloudfront.yml
@@ -65,6 +65,13 @@ Resources:
               SSEAlgorithm: AES256
       VersioningConfiguration:
         Status: Enabled
+  WwwRedirectBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: !Sub "www.${UrlPrefix}${HostedZoneName}"
+      WebsiteConfiguration:
+        RedirectAllRequestsTo:
+          HostName: !Join ['', [!Ref UrlPrefix, !Ref HostedZoneName]]
   DNS:
     Type: AWS::Route53::RecordSetGroup
     Properties:
@@ -75,7 +82,13 @@ Resources:
           Type: A
           AliasTarget:
             DNSName: !GetAtt [ CloudfrontDistribution, DomainName ]
-            HostedZoneId: Z2FDTNDATAQYW2 # See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html
+            # See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html
+            HostedZoneId: Z2FDTNDATAQYW2
+        - Name: !Sub "www.${UrlPrefix}${HostedZoneName}."
+          Type: A
+          AliasTarget:
+            DNSName: s3-website.us-east-2.amazonaws.com
+            HostedZoneId: Z2O1EMRO9K5GLX
 Outputs:
   S3WebsiteBucketWebsiteURL:
     Description: The S3 bucket used for static web hosting


### PR DESCRIPTION
Solves: https://github.com/midohiofoodbank/freshtrak-infrastructure/issues/6

This pr adds an empty S3 bucket that is configured to redirect all requests to `freshtrak.com` (`beta.freshtrak.com` for beta).

I deployed it to beta for testing. Going to www.beta.freshtrak.com should automatically redirect you to beta.freshtrak.com.